### PR TITLE
Added CitySerializer to VolunteerSerializer.

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -30,10 +30,17 @@ class RegistrationSerializer(serializers.ModelSerializer):
         return volunteer
 
 
+class CitySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = City
+        fields = ['name', 'x', 'y']
+
+
 class VolunteerSerializer(serializers.ModelSerializer):
     gender = serializers.CharField(source='get_gender_display')
     moving_way = serializers.CharField(source='get_moving_way_display')
     wanted_assignments = serializers.ListField(source='get_wanted_assignments_list')
+    city = CitySerializer()
 
     class Meta:
         model = Volunteer


### PR DESCRIPTION
Added CitySerializer to VolunteerSerializer. 
Now, in REST api in list volunteers, every volunteer's city has also the city x, and y (as in the model defined in client/models.).

Closes #265 