### PR TITLE
Added export helprequest/volunteer endpoints w/ filtering

### DIFF
--- a/API.md
+++ b/API.md
@@ -99,6 +99,7 @@ Available scopes:
 | register          | 1                          | 5 seconds |
 | send-sms          | 1                          | 5 minutes |
 | check-sms         | 1                          | 2 seconds | 
+| export-excel-data | 1                          | 5 seconds | 
 
 Requests denied by throttling have the `429 Too Many Requests` status code and the following response (where X is the
 no. of seconds left):
@@ -688,3 +689,39 @@ characters):
 }
 ```
 
+## `/api/exportvolunteers`
+
+* _This view requires authentication. See "Token Authentication" section for more details._
+* _This view is filterable. See "Filtering" section above for more details & the filters available here._
+
+**Description**: Exports volunteers into an `.xls` (Excel) file, according to the specified filters.
+
+**Allowed methods**: GET
+
+**Throttling**: `export-excel-data`, user throttle
+
+#### Response
+_This endpoint is special_ - when accessed, it returns the downloadable resource file as the response directly, and not
+a JSON response.
+
+#### Available Filters
+See `/api/volunteers` available filters.
+
+
+## `/api/exporthelprequests`
+
+* _This view requires authentication. See "Token Authentication" section for more details._
+* _This view is filterable. See "Filtering" section above for more details & the filters available here._
+
+**Description**: Exports help requests into an `.xls` (Excel) file, according to the specified filters.
+
+**Allowed methods**: GET
+
+**Throttling**: `export-excel-data`, user throttle
+
+#### Response
+_This endpoint is special_ - when accessed, it returns the downloadable resource file as the response directly, and not
+a JSON response.
+
+#### Available Filters
+See `/api/helprequests` available filters.

--- a/api/filters.py
+++ b/api/filters.py
@@ -1,0 +1,52 @@
+import django_filters as filters
+
+from client.models import Volunteer, HelpRequest
+
+
+class VolunteerFilter(filters.FilterSet):
+    num_helprequests = filters.NumberFilter(lookup_expr='exact')
+    num_helprequests__gt = filters.NumberFilter(method='num_helprequests_gt')
+    num_helprequests__lt = filters.NumberFilter(method='num_helprequests_lt')
+
+    def num_helprequests_gt(self, queryset, field_name, value):
+        return queryset.filter(num_helprequests__gt=value)
+
+    def num_helprequests_lt(self, queryset, field_name, value):
+        return queryset.filter(num_helprequests__lt=value)
+
+    class Meta:
+        model = Volunteer
+        fields = {
+            'id': ['exact'],
+            'first_name': ['exact', 'icontains'],
+            'last_name': ['exact', 'icontains'],
+            'tz_number': ['exact', 'icontains'],
+            'phone_number': ['exact', 'icontains'],
+            'date_of_birth': ['gt', 'lt', 'exact'],
+            'age': ['gt', 'lt', 'exact'],
+            'gender': ['exact'],
+            'city': ['exact', 'in'],
+            'neighborhood': ['exact', 'icontains'],
+            'city__region': ['exact'],
+            'moving_way': ['exact'],
+            'week_assignments_capacity': ['exact', 'range'],
+            'wanted_assignments': ['exact'],
+            'score': ['exact'],
+            'created_date': ['gt', 'lt', 'exact'],
+            'organization': ['exact', 'in']
+        }
+
+
+class HelpRequestsFilter(filters.FilterSet):
+    class Meta:
+        model = HelpRequest
+        fields = {
+            'id': ['exact'],
+            'city': ['exact', 'in'],
+            'city__region': ['exact', 'in'],
+            'status': ['exact', 'in'],
+            'type': ['exact', 'in'],
+            'helping_volunteer__id': ['exact'],
+            'notes': ['icontains'],
+            'phone_number': ['exact'],
+        }

--- a/api/throttling.py
+++ b/api/throttling.py
@@ -3,6 +3,18 @@ from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 # TODO find a way to do this with metaclasses to reduce code duplication
 
 
+class ExportExcelDataThrottle(UserRateThrottle):
+    scope = 'export-excel-data'
+    THROTTLE_SECONDS = 5
+
+    def parse_rate(self, rate):
+        """
+        This function parses the string rate given (e.g 1/second). We ignore it and return a custom answer.
+        :returns: tuple (int, int) (<allowed number of requests>, <period of time in seconds>)
+        """
+        return 1, type(self).THROTTLE_SECONDS
+
+
 class CityAutocompleteThrottle(AnonRateThrottle):
     scope = 'city-autocomplete'
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -35,6 +35,8 @@ router.register(r'areas', api.views.AreasViewSet, basename='area_list')
 router.register(r'languages', api.views.LanguagesViewSet, basename='language_list')
 router.register(r'sendverificationcode', api.views.SendVerificationCodeViewSet, basename='send_verification_code')
 router.register(r'checkverificationcode', api.views.CheckVerificationCodeViewSet, basename='check_verification_code')
+router.register(r'exportvolunteers', api.views.ExportVolunteersViewSet, basename='export_volunteers_xls')
+router.register(r'exporthelprequests', api.views.ExportHelpRequestsViewSet, basename='export_helprequests_xls')
 
 authTokenView = \
     swagger_auto_schema(

--- a/levechad/settings.py
+++ b/levechad/settings.py
@@ -234,6 +234,7 @@ REST_FRAMEWORK = {
         'register': '',  # overridden in throttling.py
         'send-sms': '',  # overridden in throttling.py
         'check-sms': '',  # overridden in throttling.py
+        'export-excel-data': '',  # overridden in throttling.py
     },
 }
 # Add extra authentication option to support swagger. Removed from PROD to keep minimal surface.

--- a/server/resources.py
+++ b/server/resources.py
@@ -1,7 +1,8 @@
 from import_export import resources
 from import_export.fields import Field
+from import_export.widgets import ManyToManyWidget, DateWidget
 
-from client.models import Volunteer, HelpRequest
+from client.models import Volunteer, HelpRequest, Language, Area
 
 
 class VolunteerResource(resources.ModelResource):
@@ -13,8 +14,8 @@ class VolunteerResource(resources.ModelResource):
     date_of_birth = Field(attribute='date_of_birth', column_name='תאריך לידה', default='')
     organization = Field(attribute='organization', column_name='ארגון', default='')
     phone_number = Field(attribute='phone_number', column_name='מספר טלפון', default='')
-    areas = Field(attribute='areas', column_name='איזור מגורים', default='')
-    languages = Field(attribute='languages', column_name='שפות', default='')
+    areas = Field(attribute='areas', column_name='איזור מגורים', default='', widget=ManyToManyWidget(Area))
+    languages = Field(attribute='languages', column_name='שפות', default='', widget=ManyToManyWidget(Language))
     email = Field(attribute='email', column_name='אימייל', default='')
     city = Field(attribute='city', column_name='עיר', default='')
     neighborhood = Field(attribute='neighborhood', column_name='שכונת מגורים', default='')
@@ -29,7 +30,8 @@ class VolunteerResource(resources.ModelResource):
     notes = Field(attribute='notes', column_name='הערות', default='')
     moving_way = Field(attribute='get_moving_way_display', column_name='אמצעי תחבורה', default='')
     hearing_way = Field(attribute='get_hearing_way_display', column_name='איך שמע על לב אחד', default='')
-    created_date = Field(attribute='created_date', column_name='מועד הרשמה', default='')
+    created_date = Field(attribute='created_date', column_name='מועד הרשמה', default='',
+                         widget=DateWidget(format='%d.%m.%Y %H:%M:%S'))
 
     class Meta:
         model = Volunteer
@@ -69,7 +71,8 @@ class VolunteerResource(resources.ModelResource):
 
 class HelpRequestResource(resources.ModelResource):
     id = Field(attribute='id', column_name='מזהה בקשה', default='')
-    created_date = Field(attribute='created_date', column_name='תאריך הבקשה', default='')
+    created_date = Field(attribute='created_date', column_name='תאריך הבקשה', default='',
+                         widget=DateWidget(format='%d.%m.%Y %H:%M:%S'))
     full_name = Field(attribute='full_name', column_name='שם פונה', default='')
     phone_number = Field(attribute='phone_number', column_name='טלפון', default='')
     area = Field(attribute='area', column_name='איזור', default='')


### PR DESCRIPTION
 - Added export helprequest/volunteer API endpoints, with filtering supported
 - Moved filters to filters.py file
 - Formatting fixes for exported .xls files (date format fixes, M2M objects display fixes)

This makes the export views in the `server` app obsolete (even though they share a lot of the code, other than the filtering which is exclusive for these new endpoints).